### PR TITLE
Fix version placeholder in xdigest.pc.in

### DIFF
--- a/build/xdigest.pc.in
+++ b/build/xdigest.pc.in
@@ -4,7 +4,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/xdigest
 
 Name: libxdigest
 Description: Extremly fast digest algorithms
-Version: @XDIGEST_VERSION@
+Version: @XDIG_VERSION@
 Requires:
 Libs: -L${libdir} -lxdigest
 Cflags: -I${includedir}


### PR DESCRIPTION
Ensures the pkgconfig files contains a version. XDIGEST_VERSION is not set CMakeConfig.txt. Uses XDIG_VERSION.


Testing done:

````
$ rpm -q --provides -p /var/tmp/build-root/openSUSE_Tumbleweed-x86_64/home/abuild/rpmbuild/RPMS/x86_64/xdigest-devel-0.4.0-0.x86_64.rpm | grep pkgconfig
pkgconfig(xdigest) = 0.4.0
````